### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1
+
+# This is a multi-stage image. First we build an image with the executable binary.
+# There is a problem, the resulting image is too heavy because it contains the go toolkit, 
+# which is useless after obtaining the executable binary.
+# In order to obtain a smaller image, we build a second image, which will be used
+# for deploying the app
+
+### ------------- Deploy Image ------------- ###
+FROM golang:1.19-alpine as build
+
+WORKDIR /app
+
+# Resolve project dependencies
+COPY go.mod ./
+COPY go.sum ./
+RUN go mod download
+
+# Copy all source files
+COPY . ./
+
+# Build executable from source files
+RUN go build -o /go-seed
+
+### ------------- Deploy Image ------------- ###
+FROM alpine
+
+WORKDIR /
+
+COPY --from=build /go-seed /go-seed
+
+EXPOSE 8080
+
+ENTRYPOINT ["/go-seed"]


### PR DESCRIPTION
**Multistage Dockefile**
Added new Dockerfile with two stages:

- First stage: builds an image with the executable binary using Go Alpine as base image. There is a problem with this first image, its too heavy (~361MB) even using an Go Alpine base image, because of this we build a second image which will only contain the executable binary
- Second stage: builds an image with the executable binary using Alpine as base image. This image does not contain all the Go toolkit, it only contains Alpine source files and a copy of the executable binary obtained in the first step. As a result, we obtain a really small image.

**Testing**
In order to test the image these commands were executed:
```
docker build -t go-seed
docker run -d -p 8080:8080 go-seed
curl -X GET 'localhost:8080/pokemon/1'
```